### PR TITLE
Currently unable to use the create

### DIFF
--- a/packages/create/bin/create-vessel.js
+++ b/packages/create/bin/create-vessel.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { run } from '../dist/cli.js';
 
 async function main() {


### PR DESCRIPTION
Using Mac OS I'm currently unable to run `yarn create vessel` and `npx create-vessel` with the errors

```sh
/Users/.../.yarn/bin/create-vessel: line 1: import: command not found
/Users/.../.yarn/bin/create-vessel: line 3: syntax error near unexpected token `('
/Users/.../.yarn/bin/create-vessel: line 3: `async function main() {'
```

Apparently adding a shebang at the start of create-vessel.js should make yarn use the node runtime to run the script